### PR TITLE
Defer to `defaultContext` more flexibly

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -181,11 +181,20 @@ export const router = kea<routerType>([
 ])
 
 export function getRouterContext(): RouterPluginContext {
-  const context: RouterPluginContext | undefined = getPluginContext('router')
+  let context: RouterPluginContext | undefined = getPluginContext('router')
   if (!context || !context.history || !context.location) {
     const defaultContext = getDefaultContext()
-    setRouterContext({ ...defaultContext, ...context })
-    return defaultContext
+    if (!context) {
+      context = defaultContext
+      setRouterContext(context)
+    } else {
+      if (!context.history) {
+        context.history = defaultContext.history
+      }
+      if (!context.location) {
+        context.location = defaultContext.location
+      }
+    }
   }
   return context
 }


### PR DESCRIPTION
949cbce7e434731bbc43493fd31e01ea95bef321 broke routing. This fixes it, and hopefully also fixes the issue 949cbce7e434731bbc43493fd31e01ea95bef321 was meant to solve.