### PR TITLE
Fix: Use more advanced equality for paths

### DIFF
--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -1,7 +1,7 @@
 /* global test, expect */
 import '@babel/polyfill'
 
-import { encodeParams, decodeParams, combineUrl } from '../utils'
+import {encodeParams, decodeParams, combineUrl, arePathsEqual} from '../utils'
 
 test('encode & decode works', async () => {
   const reverseOptions = [
@@ -87,5 +87,23 @@ test('combineUrl works', async () => {
 
   expect(combineUrl('/path')).toEqual({ url: '/path', pathname: '/path', search: '', searchParams: {}, hash: '', hashParams: {} })
   expect(combineUrl('/path?a=b#hash=value')).toEqual({ url: '/path?a=b#hash=value', pathname: '/path', search: '?a=b', searchParams: { a: 'b' }, hash: '#hash=value', hashParams: { hash: 'value' } })
+
+})
+
+test('arePathsEqual works', async () => {
+  expect(arePathsEqual('/path', '/path')).toBe(true)
+  expect(arePathsEqual('/path?a=b+c', '/path?a=b%20c')).toBe(true)
+  expect(arePathsEqual('/path?a=b+c', '/path?a=b c')).toBe(true)
+  expect(arePathsEqual('/path?', '/path')).toBe(true)
+  expect(arePathsEqual('/path?a=1&b=2', '/path?b=2&a=1')).toBe(true)
+
+  expect(arePathsEqual('/path', '/other-path')).toBe(false)
+  expect(arePathsEqual('/path', '/path/')).toBe(false)
+  expect(arePathsEqual('/path', '/path/other')).toBe(false)
+  expect(arePathsEqual('/path', '/path#foo')).toBe(false)
+  expect(arePathsEqual('/path#1', '/path#2')).toBe(false)
+  expect(arePathsEqual('/path?a=1&b=2', '/path?a=1')).toBe(false)
+  expect(arePathsEqual('/path?a=1', '/path?a=1&b=2')).toBe(false)
+
 
 })

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -1,7 +1,7 @@
 /* global test, expect */
 import '@babel/polyfill'
 
-import {encodeParams, decodeParams, combineUrl, arePathsEqual} from '../utils'
+import { encodeParams, decodeParams, combineUrl, arePathsEqual } from '../utils'
 
 test('encode & decode works', async () => {
   const reverseOptions = [

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -96,6 +96,9 @@ test('arePathsEqual works', async () => {
   expect(arePathsEqual('/path?a=b+c', '/path?a=b c')).toBe(true)
   expect(arePathsEqual('/path?', '/path')).toBe(true)
   expect(arePathsEqual('/path?a=1&b=2', '/path?b=2&a=1')).toBe(true)
+  expect(arePathsEqual('/path#', '/path')).toBe(true)
+  expect(arePathsEqual('/path#foo', '/path#foo')).toBe(true)
+  expect(arePathsEqual('/path?a=1&b=2#foo', '/path?b=2&a=1#foo')).toBe(true)
 
   expect(arePathsEqual('/path', '/other-path')).toBe(false)
   expect(arePathsEqual('/path', '/path/')).toBe(false)
@@ -104,6 +107,6 @@ test('arePathsEqual works', async () => {
   expect(arePathsEqual('/path#1', '/path#2')).toBe(false)
   expect(arePathsEqual('/path?a=1&b=2', '/path?a=1')).toBe(false)
   expect(arePathsEqual('/path?a=1', '/path?a=1&b=2')).toBe(false)
-
-
+  expect(arePathsEqual('/path#1', '/path#2')).toBe(false)
+  expect(arePathsEqual('/path?a=1&b=2#foo', '/path?b=2&a=1#bar')).toBe(false)
 })

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -1,7 +1,7 @@
 import { getRouterContext, router } from './router'
 import UrlPattern from 'url-pattern'
 import { ActionToUrlPayload, BeforeUnloadPayload, LocationChangedPayload, UrlToActionPayload } from './types'
-import { stringOrObjectToString } from './utils'
+import {arePathsEqual, stringOrObjectToString} from './utils'
 import { afterMount, beforeUnmount, BuiltLogic, connect, getContext, listeners, Logic, LogicBuilder } from 'kea'
 
 function assureConnectionToRouter<L extends Logic = Logic>(logic: BuiltLogic<L>) {
@@ -46,7 +46,7 @@ export function actionToUrl<L extends Logic = Logic>(
             stringOrObjectToString(pathInRoutes[2], '#')
           : pathFromRoutesToWindow(pathInRoutes)
 
-        if (currentPathInWindow !== pathInWindow) {
+        if (!arePathsEqual(currentPathInWindow, pathInWindow)) {
           if (Array.isArray(pathInRoutes) && pathInRoutes[3] && pathInRoutes[3].replace) {
             router.actions.replace(pathInWindow)
           } else {

--- a/src/builders.ts
+++ b/src/builders.ts
@@ -1,7 +1,7 @@
 import { getRouterContext, router } from './router'
 import UrlPattern from 'url-pattern'
 import { ActionToUrlPayload, BeforeUnloadPayload, LocationChangedPayload, UrlToActionPayload } from './types'
-import {arePathsEqual, stringOrObjectToString} from './utils'
+import { stringOrObjectToString } from './utils'
 import { afterMount, beforeUnmount, BuiltLogic, connect, getContext, listeners, Logic, LogicBuilder } from 'kea'
 
 function assureConnectionToRouter<L extends Logic = Logic>(logic: BuiltLogic<L>) {
@@ -38,7 +38,7 @@ export function actionToUrl<L extends Logic = Logic>(
         if (typeof pathInRoutes === 'undefined') {
           return
         }
-        const { pathFromRoutesToWindow } = getRouterContext()
+        const { pathFromRoutesToWindow, arePathsEqual } = getRouterContext()
 
         const pathInWindow = Array.isArray(pathInRoutes)
           ? pathFromRoutesToWindow(pathInRoutes[0]) +

--- a/src/router.ts
+++ b/src/router.ts
@@ -12,8 +12,8 @@ import {
   beforeUnmount,
   setPluginContext,
 } from 'kea'
-import { CombinedLocation, combineUrl, decodeParams as decode, encodeParams as encode } from './utils'
-import { routerType } from './routerType'
+import { arePathsEqual, CombinedLocation, combineUrl, decodeParams as decode, encodeParams as encode } from './utils'
+import type { routerType } from './routerType'
 import { LocationChangedPayload, RouterLocation, RouterPluginContext } from './types'
 
 function preventUnload(newLocation?: CombinedLocation): boolean {
@@ -199,6 +199,9 @@ export function getRouterContext(): RouterPluginContext {
       if (!context.location) {
         context.location = defaultContext.location
       }
+      if (!context.arePathsEqual) {
+        context.arePathsEqual = defaultContext.arePathsEqual
+      }
     }
   }
   return context
@@ -227,6 +230,7 @@ export function getDefaultContext(): RouterPluginContext {
       typeof window !== 'undefined' && typeof window.history.state?.count === 'number'
         ? window.history.state?.count
         : null,
+    arePathsEqual,
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export interface RouterPluginOptions {
   encodeParams?: (obj: Record<string, any>, symbol: string) => string
   decodeParams?: (input: string, symbol: string) => Record<string, any>
   urlPatternOptions?: UrlPatternOptions
+  arePathsEqual?: (path1: string, path2: string) => boolean
 }
 
 export interface RouterPluginContext extends RouterPluginOptions {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -128,21 +128,20 @@ export function arePathsEqual(a: string, b: string) {
   const decodedSearchA = decodeParams(parsedA.search, '?')
   const decodedSearchB = decodeParams(parsedB.search, '?')
 
-  const searchParamsA = [...Object.entries(decodedSearchA)].sort();
-  const searchParamsB = [...Object.entries(decodedSearchB)].sort();
+  const searchParamsA = [...Object.entries(decodedSearchA)].sort()
+  const searchParamsB = [...Object.entries(decodedSearchB)].sort()
 
   // Compare the sorted search parameters
   if (searchParamsA.length !== searchParamsB.length) {
-    return false;
+    return false
   }
 
   for (let i = 0; i < searchParamsA.length; i++) {
     if (searchParamsA[i][0] !== searchParamsB[i][0] || searchParamsA[i][1] !== searchParamsB[i][1]) {
-      return false;
+      return false
     }
   }
   return true
-
 }
 
 export interface CombinedLocation {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -116,6 +116,35 @@ export function parsePath(
 const _e = encodeParams
 const _d = decodeParams
 
+
+export function arePathsEqual(a: string, b: string) {
+  // both paths need to be parsed, as the raw strings might just have differences in encoding rather than in value,
+  // e.g. /a?b+c and /a?b%20c
+  const parsedA = parsePath(a)
+  const parsedB = parsePath(b)
+  if (parsedA.pathname !== parsedB.pathname || parsedA.hash !== parsedB.hash) {
+    return false
+  }
+  const decodedSearchA = decodeParams(parsedA.search, '?')
+  const decodedSearchB = decodeParams(parsedB.search, '?')
+
+  const searchParamsA = [...Object.entries(decodedSearchA)].sort();
+  const searchParamsB = [...Object.entries(decodedSearchB)].sort();
+
+  // Compare the sorted search parameters
+  if (searchParamsA.length !== searchParamsB.length) {
+    return false;
+  }
+
+  for (let i = 0; i < searchParamsA.length; i++) {
+    if (searchParamsA[i][0] !== searchParamsB[i][0] || searchParamsA[i][1] !== searchParamsB[i][1]) {
+      return false;
+    }
+  }
+  return true
+
+}
+
 export interface CombinedLocation {
   pathname: string
   search: string


### PR DESCRIPTION
There are a few different valid encodings of some URLs. For example, the query parameters might be in a different order, or the space symbol might be encoded as a `+` (what `URLSearchParams` `toString()` does) or as `%20` (what `encodeURIComponent` does).

We should treat these paths as equals, by parsing the paths and checking that the query param objects have equal entries.

(This change fixes a bug in posthog where web analytics gets stuck in an endless loop if you choose a custom event with a space in it as your conversion goal.)

I didn't touch hash params, as they aren't guaranteed to be in a particular format, so it's not necessarily valid to say that using query-like parameters with a different ordering means equal paths.