### PR TITLE
Use `fast-deep-equal` for search params in `arePathsEqual`

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "eslint-plugin-promise": "^4.1.1",
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-standard": "^4.0.0",
+    "fast-deep-equal": "^3.1.1",
     "jest": "^26.0.1",
     "jest-environment-node-debug": "^2.0.0",
     "jsdom": "^16.2.2",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import { getPluginContext } from 'kea'
+import equal from 'fast-deep-equal'
 
 function parseValue(value: string | null): any {
   if (!Number.isNaN(Number(value)) && typeof value === 'string' && value.trim() !== '') {
@@ -28,7 +29,7 @@ function serializeValue(value: any): string {
   return value
 }
 
-export function decodeParams(input: string, symbol: string = ''): Record<string, any> {
+export function decodeParams(input: string, symbol = ''): Record<string, any> {
   if (symbol && input.indexOf(symbol) === 0) {
     input = input.slice(1)
   }
@@ -52,7 +53,7 @@ export function decodeParams(input: string, symbol: string = ''): Record<string,
   return ret
 }
 
-export function encodeParams(obj: Record<string, any>, symbol: string = ''): string {
+export function encodeParams(obj: Record<string, any>, symbol = ''): string {
   if (typeof obj !== 'object') {
     return ''
   }
@@ -82,9 +83,7 @@ export function stringOrObjectToString(input: any, symbol: string): string {
 }
 
 // copied from react-router! :)
-export function parsePath(
-  path: string,
-): {
+export function parsePath(path: string): {
   pathname: string
   search: string
   hash: string
@@ -116,7 +115,6 @@ export function parsePath(
 const _e = encodeParams
 const _d = decodeParams
 
-
 export function arePathsEqual(a: string, b: string) {
   // both paths need to be parsed, as the raw strings might just have differences in encoding rather than in value,
   // e.g. /a?b+c and /a?b%20c
@@ -137,7 +135,7 @@ export function arePathsEqual(a: string, b: string) {
   }
 
   for (let i = 0; i < searchParamsA.length; i++) {
-    if (searchParamsA[i][0] !== searchParamsB[i][0] || searchParamsA[i][1] !== searchParamsB[i][1]) {
+    if (searchParamsA[i][0] !== searchParamsB[i][0] || !equal(searchParamsA[i][1], searchParamsB[i][1])) {
       return false
     }
   }


### PR DESCRIPTION
Solves duplicate history entries: https://github.com/PostHog/posthog/pull/27911#discussion_r1932333999

Resorted to `fast-deep-equal` here, which actually already was bundled because its an existing (transitive) dependency!